### PR TITLE
Switch raw TYPO3 data property to "text" type

### DIFF
--- a/typo3Model.xml
+++ b/typo3Model.xml
@@ -68,7 +68,7 @@
                   <multiple>false</multiple>
 			  </property>
 			  <property name="dkd:typo3:general:record_data">
-				  <type>d:content</type>
+				  <type>d:text</type>
                   <multiple>false</multiple>
 			  </property>
           </properties>


### PR DESCRIPTION
Using "content" as type seems to fail with a big error from Alfresco. Text does not.
