### PR TITLE
Add generic "references file" relation type

### DIFF
--- a/typo3Model.xml
+++ b/typo3Model.xml
@@ -153,6 +153,20 @@
                   <multiple>false</multiple>
               </property>
           </properties>
+          <associations>
+              <association name="dkd:typo3:relation:references_file">
+                  <title>References file</title>
+                  <source>
+                      <mandatory>false</mandatory>
+                      <many>true</many>
+                  </source>
+                  <target>
+                      <class>dkd:typo3:sys_file</class>
+                      <mandatory>false</mandatory>
+                      <many>false</many>
+                  </target>
+              </association>
+          </associations>
       </aspect>
   </aspects>
 </model>


### PR DESCRIPTION
The relation type is specific to TYPO3 files and covers 1) any file existing only in TYPO3, and 2) any file uploaded to CMIS via TYPO3's CMIS-FAL driver. It is placed in the general aspect as a way to provide default support for file relations for any record type without explicitly defining a uniquely named relation for each record type.
